### PR TITLE
Added YouTube search support

### DIFF
--- a/RedditRadio.js
+++ b/RedditRadio.js
@@ -240,8 +240,7 @@ class RedditRadio
 			} else {
 				console.log("Built-in command from offline member: " + cmdID);
 			}
-			parse.shift();
-			this[cmdName].apply(this, [ msg ].concat(parse.join(' ')));
+			this[cmdName].apply(this, [ msg ].concat(parse.slice(1)));
 			return;
 		}
 
@@ -374,6 +373,15 @@ class RedditRadio
 			return;
 		}
 
+		if (url === undefined) {
+			msg.channel.send("You have to give me a URL, otherwise I don't know what to play. :sob:");
+			return;
+		}
+
+		var args = Array.from(arguments);
+		args.shift();
+		var query = args.join(' ');
+
 		if (this.voice_connection === false) {
 			if (!msg.member.voiceChannel) {
 				msg.channel.send("You need to be in a voice channel. :frowning2:");
@@ -390,17 +398,12 @@ class RedditRadio
 
 				msg.channel.send("Hello! :wave:");
 
-				this.queue.add(url, (song) => { this.onSongAdded(msg, song, false); });
+				this.queue.add(query, (song) => { this.onSongAdded(msg, song, false); });
 			});
 			return;
 		}
 
-		if (url === undefined) {
-			msg.channel.send("You have to give me a URL, otherwise I don't know what to play. :sob:");
-			return;
-		}
-
-		this.queue.add(url, (song) => { this.onSongAdded(msg, song, false); });
+		this.queue.add(query, (song) => { this.onSongAdded(msg, song, false); });
 	}
 
 	onCmdPlayNow(msg, url)
@@ -410,6 +413,15 @@ class RedditRadio
 			return;
 		}
 
+		if (url === undefined) {
+			msg.channel.send("You have to give me a URL, otherwise I don't know what to play. :sob:");
+			return;
+		}
+
+		var args = Array.from(arguments);
+		args.shift();
+		var query = args.join(' ');
+
 		if (this.voice_connection === false) {
 			if (!msg.member.voiceChannel) {
 				msg.channel.send("You need to be in a voice channel. :frowning2:");
@@ -426,17 +438,12 @@ class RedditRadio
 
 				msg.channel.send("Hello! :wave:");
 
-				this.queue.add(url, (song) => { this.onSongAdded(msg, song, false); });
+				this.queue.add(query, (song) => { this.onSongAdded(msg, song, false); });
 			});
 			return;
 		}
 
-		if (url === undefined) {
-			msg.channel.send("You have to give me a URL, otherwise I don't know what to play. :sob:");
-			return;
-		}
-
-		this.queue.insert(url, (song) => { this.onSongAdded(msg, song, true); });
+		this.queue.insert(query, (song) => { this.onSongAdded(msg, song, true); });
 	}
 
 	onCmdPause(msg)

--- a/RedditRadio.js
+++ b/RedditRadio.js
@@ -240,7 +240,8 @@ class RedditRadio
 			} else {
 				console.log("Built-in command from offline member: " + cmdID);
 			}
-			this[cmdName].apply(this, [ msg ].concat(parse.slice(1)));
+			parse.shift();
+			this[cmdName].apply(this, [ msg ].concat(parse.join(' ')));
 			return;
 		}
 

--- a/Song.js
+++ b/Song.js
@@ -37,8 +37,14 @@ class Song
 				key: config.youtube.token
 			};
 			yt_search(url, options, (error, results) => {
-				if (error) return console.log(error);
-				if (results.length <= 0) return console.log('No YouTube results for ' + url);
+				if (error) {
+					console.log(error);
+					return;
+				}
+				if (results.length <= 0) {
+					console.log("Failed to search Youtube: \"" + error + "\"");
+					return 
+				}
 			 	this.url = results[0].link;
 				this.makeYoutubeStream(callback);
 			});

--- a/Song.js
+++ b/Song.js
@@ -5,14 +5,14 @@ var yt_search = require('youtube-search');
 
 class Song
 {
-	constructor(config, url, callback)
+	constructor(config, query, callback)
 	{
-		var wrappedUrl = url.match(/^<(.+)>$/);
+		var wrappedUrl = query.match(/^<(.+)>$/);
 		if (wrappedUrl) {
-			url = wrappedUrl[1];
+			query = wrappedUrl[1];
 		}
 
-		this.url = url;
+		this.url = query;
 		this.valid = false;
 
 		this.title = "";
@@ -20,36 +20,36 @@ class Song
 		this.image = "";
 		this.live = false;
 
-		if (url.match(/^(https?\:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)/)) {
+		if (query.match(/^(https?\:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)/)) {
 			this.makeYoutubeStream(callback);
-		} else if (url.match(/^https:\/\/soundcloud.com\/[^\/]+\/.+$/)) {
+		} else if (query.match(/^https:\/\/soundcloud.com\/[^\/]+\/.+$/)) {
 			this.makeSoundcloudStream(config.soundcloud, callback);
-		} else if (url.match(/^https:\/\/www\.facebook\.com\/.*\/videos\/[0-9]+/)) {
+		} else if (query.match(/^https:\/\/www\.facebook\.com\/.*\/videos\/[0-9]+/)) {
 			this.makeFacebookStream(callback);
-		} else if (url.match(/^https:\/\/www.pscp.tv\/w\/[A-Za-z0-9]{13}/)) {
+		} else if (query.match(/^https:\/\/www.pscp.tv\/w\/[A-Za-z0-9]{13}/)) {
 			this.makePeriscopeStream(callback);
-		} else if (url.endsWith(".mp3") && (url.startsWirth("http://") || url.startsWith("https://"))) {
+		} else if (query.endsWith(".mp3") && (query.startsWirth("http://") || query.startsWith("https://"))) {
 			this.makeMP3Stream(callback);
 		} else if (config.youtube && config.youtube.token) {
-			console.log("Searching in YouTube: " + url);
+			console.log("Searching in YouTube: " + query);
 			var options = {
 				maxResults: 1,
 				key: config.youtube.token
 			};
-			yt_search(url, options, (error, results) => {
+			yt_search(query, options, (error, results) => {
 				if (error) {
 					console.log("Failed to search Youtube: \"" + error + "\"");
 					return;
 				}
 				if (results.length <= 0) {
-					console.log("No Youtube results were found for \"" + url + "\"");
+					console.log("No Youtube results were found for \"" + query + "\"");
 					return 
 				}
 			 	this.url = results[0].link;
 				this.makeYoutubeStream(callback);
 			});
 		} else {
-			console.log("Unrecognized url: " + url);
+			console.log("Unrecognized url: " + query);
 			callback(this);
 		}
 	}

--- a/Song.js
+++ b/Song.js
@@ -1,6 +1,7 @@
 var ytdl = require("ytdl-core");
 var https = require("follow-redirects").https;
 var url = require("url");
+var yt_search = require('youtube-search');
 
 class Song
 {
@@ -29,6 +30,18 @@ class Song
 			this.makePeriscopeStream(callback);
 		} else if (url.endsWith(".mp3") && (url.startsWirth("http://") || url.startsWith("https://"))) {
 			this.makeMP3Stream(callback);
+		} else if (config.youtube && config.youtube.token) {
+			console.log("Searching in YouTube: " + url);
+			var options = {
+				maxResults: 1,
+				key: config.youtube.token
+			};
+			yt_search(url, options, (error, results) => {
+				if (error) return console.log(error);
+				if (results.length <= 0) return console.log('No YouTube results for ' + url);
+			 	this.url = results[0].link;
+				this.makeYoutubeStream(callback);
+			});
 		} else {
 			console.log("Unrecognized url: " + url);
 			callback(this);

--- a/Song.js
+++ b/Song.js
@@ -38,11 +38,11 @@ class Song
 			};
 			yt_search(url, options, (error, results) => {
 				if (error) {
-					console.log(error);
+					console.log("Failed to search Youtube: \"" + error + "\"");
 					return;
 				}
 				if (results.length <= 0) {
-					console.log("Failed to search Youtube: \"" + error + "\"");
+					console.log("No Youtube results were found for \"" + url + "\"");
 					return 
 				}
 			 	this.url = results[0].link;

--- a/SongQueue.js
+++ b/SongQueue.js
@@ -9,9 +9,9 @@ class SongQueue
 		this.list = [];
 	}
 
-	add(url, callback)
+	add(query, callback)
 	{
-		new Song(this.config, url, (song) => {
+		new Song(this.config, query, (song) => {
 			if (!song.valid) {
 				callback(false);
 				return;
@@ -21,9 +21,9 @@ class SongQueue
 		});
 	}
 
-	insert(url, callback)
+	insert(query, callback)
 	{
-		new Song(this.config, url, (song) => {
+		new Song(this.config, query, (song) => {
 			if (!song.valid) {
 				callback(false);
 				return;

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,6 +18,9 @@ bitrate = 44100
 [soundcloud]
 client_id = "soundcloud_client_id"
 
+[youtube]
+token = "youtube_token_here"
+
 [[radios]]
 token = "radio_bot_1_token"
 channel = "330121740758024193"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node-opus": "^0.2.7",
     "toml": "^2.3.3",
     "twitter": "^1.7.1",
+    "youtube-search": "^1.0.10",
     "ytdl-core": "^0.17.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Using `youtube-search` package, bot can now search for songs in YouTube. Search starts when unsupported URL is given using `.play` command and YouTube API token is specified in `config.toml`.

YouTube Data API v3
https://developers.google.com/youtube/v3/getting-started